### PR TITLE
Test PR

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,4 +21,5 @@ jobs:
       - name: get the merge commit
         if: github.event.pull_request.merged == true
         # run: echo "Merge commit is: $TAG"
-        run: echo "merge commit: $GITHUB_SHA"
+        run: |
+          echo "merge commit: $GITHUB_SHA"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Lookup the existing container image
-        if: github.event.pull_request.merged == true
         run: |
           echo "Pulling container image tagged with PR commit $PR_COMMIT_TAG"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,4 +12,4 @@ jobs:
       - name: retag container on PR merge
         # if: github.event.pull_request.merged == true
         # run: echo "Merge commit is: $TAG"
-        run: echo "Commits: ${{ github.events.commits }}"
+        run: echo "Commits: ${{ github.event.commits }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,6 @@
-on: pull_request
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize, closed ]
 env:
   TAG: ${{ github.event.pull_request.head.sha }}
 jobs:
@@ -6,15 +8,17 @@ jobs:
   get-commit:
     runs-on: ubuntu-latest
     steps:
-      - name: echo commit
+      - name: get current commit
         run: echo $TAG
 
-      # - name: retag container on PR merge
-      #   # if: github.event.pull_request.merged == true
-      #   # run: echo "Merge commit is: $TAG"
-      #   run: echo "Commits: ${{ github.event.commits }}"
-      - name: get the previous sha
+      - name: get the previous (pr) commit
+        if: github.event.pull_request.merged == true
         run: |
+          echo "PR commit:"
           echo "$GITHUB_CONTEXT"| jq '.event.commits[].id' | tail -2 | head -1 |sed 's/\"//g'
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
+      - name: get the merge commit
+        if: github.event.pull_request.merged == true
+        # run: echo "Merge commit is: $TAG"
+        run: echo "merge commit: $GITHUB_SHA"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,8 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, closed ]
 env:
-  PR_TAG: ${{ github.event.pull_request.head.sha }}
+  PR_COMMIT_TAG: ${{ github.event.pull_request.head.sha }}
+  MERGE_COMMIT_TAG: ${{ github.sha }}
 jobs:
   
   # find the image in the repository tagged with this PR's commit
@@ -14,4 +15,4 @@ jobs:
         if: github.event.pull_request.merged == true
         # run: echo "Merge commit is: $TAG"
         run: |
-          echo "Adding tag $GITHUB_SHA to the container image tagged with $PR_TAG"
+          echo "Adding merge commit tag $MERGE_COMMIT_TAG to the container image tagged with PR commit $PR_COMMIT_TAG"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,3 +9,7 @@ jobs:
       - name: echo commit
         run: echo $TAG
 
+      - name: retag container on PR merge
+        # if: github.event.pull_request.merged == true
+        # run: echo "Merge commit is: $TAG"
+        run: echo "Commits: ${{ github.events.commits }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,24 +2,16 @@ on:
   pull_request:
     types: [ opened, reopened, synchronize, closed ]
 env:
-  TAG: ${{ github.event.pull_request.head.sha }}
+  PR_TAG: ${{ github.event.pull_request.head.sha }}
 jobs:
   
-  get-commit:
+  # find the image in the repository tagged with this PR's commit
+  # add the merge commit as an additional tag for a later deploy
+  tag-image:
     runs-on: ubuntu-latest
     steps:
-      - name: get current commit
-        run: echo $TAG
-
-      - name: get the previous (pr) commit
-        if: github.event.pull_request.merged == true
-        run: |
-          echo "PR commit:"
-          echo "$GITHUB_CONTEXT"| jq '.event.commits[].id' | tail -2 | head -1 |sed 's/\"//g'
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-      - name: get the merge commit
+      - name: Add the merge commit tag
         if: github.event.pull_request.merged == true
         # run: echo "Merge commit is: $TAG"
         run: |
-          echo "merge commit: $GITHUB_SHA"
+          echo "Adding tag $GITHUB_SHA to the container image tagged with $PR_TAG"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,12 @@ jobs:
       - name: echo commit
         run: echo $TAG
 
-      - name: retag container on PR merge
-        # if: github.event.pull_request.merged == true
-        # run: echo "Merge commit is: $TAG"
-        run: echo "Commits: ${{ github.event.commits }}"
+      # - name: retag container on PR merge
+      #   # if: github.event.pull_request.merged == true
+      #   # run: echo "Merge commit is: $TAG"
+      #   run: echo "Commits: ${{ github.event.commits }}"
+      - name: get the previous sha
+        run: |
+          echo "$GITHUB_CONTEXT"| jq '.event.commits[].id' | tail -2 | head -1 |sed 's/\"//g'
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
     types: [ opened, reopened, synchronize, closed ]
 env:
   PR_COMMIT_TAG: ${{ github.event.pull_request.head.sha }}
-  MERGE_COMMIT_TAG: ${{ github.sha }}
 jobs:
   
   # find the image in the repository tagged with this PR's commit
@@ -11,8 +10,14 @@ jobs:
   tag-image:
     runs-on: ubuntu-latest
     steps:
+      - name: Lookup the existing container image
+        if: github.event.pull_request.merged == true
+        run: |
+          echo "Pulling container image tagged with PR commit $PR_COMMIT_TAG"
+
       - name: Add the merge commit tag
         if: github.event.pull_request.merged == true
-        # run: echo "Merge commit is: $TAG"
+        env:
+          MERGE_COMMIT_TAG: ${{ github.sha }}
         run: |
           echo "Adding merge commit tag $MERGE_COMMIT_TAG to the container image tagged with PR commit $PR_COMMIT_TAG"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,11 @@
+on: pull_request
+env:
+  TAG: ${{ github.event.pull_request.head.sha }}
+jobs:
+  
+  get-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: echo commit
+        run: echo $TAG
+


### PR DESCRIPTION
- `d4051ab...` is the last commit of this PR
![image](https://user-images.githubusercontent.com/12104969/131129980-eb632fc3-d59f-46bf-bb98-cbd50e1819a8.png)
- the github action uses `${{ github.event.pull_request.head.sha }}` to get that commit, and pull a previously built and tested container image with that tag

- `270126c...` is the merge commit in master, after this PR had been merged
![image](https://user-images.githubusercontent.com/12104969/131131129-052e4e6c-50cb-4082-98f1-d3ff283b5bd9.png)

- on merge, the github action adds an additional tag of the `${{ github.sha }}`  to the container image which is the merge commit (when merging a PR)
https://github.com/oldsj/test-hotfix/runs/3443320076?check_suite_focus=true
![image](https://user-images.githubusercontent.com/12104969/131130975-f9f4a588-a90a-458a-b818-e2f431d4ab1b.png)


- then, a release can be made that targets the normal merge commit in the main branch that will deploy the right container tag